### PR TITLE
docs: 更新资源文档对齐当前实现

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,29 @@
 - **space.yaml**
   - 这是整个 Space 的「入口配置文件」。
   - 它告诉系统：默认用哪个方案、哪个主题、哪些资源目录。
-  - 当前内容示例（简化解释）：
-    - `schema`: 默认输入方案名称，例如 `bim-pinyin`。
+  - 当前内容示例（简化解释，字段顺序与实际文件一致）：
+    - `schema_id`: 默认启用的具体方案 id，例如 `rime_ice_26`（对应 `schemas/bim-pinyin/rime_ice_26.schema.yaml`）。
+    - `schema`: 默认输入方案家族名称，例如 `bim-pinyin`。
     - `schema_dir`: 输入方案所在的目录，一般是 `schemas/`。
-    - `theme`: 默认主题名称，例如 `t9`。
+    - `theme`: 默认主题名称，例如 `default`。
     - `theme_dir`: 主题所在的目录，一般是 `themes/`。
+    - `font`: 默认字体方案名称，例如 `default`。
+    - `font_dir`: 字体资源目录，一般是 `fonts/`。
     - `symbol`: 默认符号方案名称，例如 `default`。
     - `symbol_dir`: 符号配置目录，一般是 `symbols/`。
     - `emoticon`: 默认表情方案名称，例如 `default`。
     - `emoticon_dir`: 表情配置目录，一般是 `emoticons/`。
+    - `speech`: 默认语音（听写/TTS）服务名称，例如 `volcengine`。
+    - `speech_dir`: 语音服务配置目录，一般是 `speeches/`。
     - `config_version`: 配置版本号，目前是 `1.0`，用来区分不同配置格式。
     - `sound_on`: 是否开启按键音效（`true/false`）。
     - `sound_volume`: 按键音量大小（数字）。
     - `sound_effect`: 使用哪一套音效资源，例如 `default`。
     - `haptics_on`: 是否开启按键振动（`true/false`）。
     - `haptics_volume`: 振动强度（数字）。
+    - `haptic`: 默认振动方案名称，例如 `system`。
+    - `haptic_dir`: 振动配置目录，一般是 `haptics/`。
+    - `global_keyboard_menu`: 全局键盘菜单项列表，定义键盘上长按 / 功能菜单里出现哪些功能按钮（如 VIP、语音识别、emoji、剪切板、Rime 切换器等）。
 
 - **LICENSE**
   - Space 仓库的开源协议文件。
@@ -68,6 +76,10 @@
   - 键盘主题相关资源：颜色、布局风格、背景等。
   - 想做「皮肤」类效果时，通常会改这里的文件。
 
+- **fonts/**
+  - 字体资源目录，每个子目录是一套字体方案（如 `default/`、`jf-openhuninn-2.1/`）。
+  - `space.yaml` 里的 `font` / `font_dir` 字段会引用这里的某套字体。
+
 - **symbols/**
   - 符号面板配置，比如各种标点、特殊符号、数学符号等如何排布。
   - 不同的 symbol 方案可以决定你看到的是「哪一套符号键盘」。
@@ -82,7 +94,12 @@
 
 - **haptics/**
   - 震动（触觉反馈）配置，比如按键时「轻震一下」还是「重点震动」。
-  - `space.yaml` 里的 `haptics_on` 和 `haptics_volume` 会影响这些效果是否启用、强度多大。
+  - `space.yaml` 里的 `haptics_on`、`haptics_volume` 控制是否启用与强度；`haptic` / `haptic_dir` 指定使用哪套振动方案。
+
+- **speeches/**
+  - 语音服务（听写 / 语音识别 / TTS）配置目录，每个子目录是一套服务（如 `default/` 本地、`volcengine/` 火山引擎）。
+  - 每套服务通常包含 `info.yaml`（界面信息）与 `speech.yaml`（provider 与凭据配置）。
+  - `space.yaml` 里的 `speech` / `speech_dir` 字段决定默认使用哪套服务。
 
 - **patches/**
   - 补丁配置，用来对现有方案做「局部修改 / 增强」。
@@ -96,6 +113,9 @@
 - **resources/**
   - 通用资源目录，里面可能包含图片、模板、配置片段等，供其他目录引用。
   - 可以理解成「共享素材库」。
+
+- **tutorials/**
+  - 面向用户 / 开发者的图文教程（Markdown），例如 `custom_phrase.md`（自定义短语教程）。
 
 ---
 
@@ -169,21 +189,31 @@
     - 你只需要在主题自己的 `theme.yaml` 里定制少量差异化内容。
 
 - **`__include` 语法：从 public 引用公共配置**
-  - 在 `t9/theme.yaml` 开头，你会看到类似这样的写法：
-    - `style: __include: ./../public/style/default:/style`
-    - `preset_styles: __include: ./../public/preset_styles/default:/preset_styles`
-    - `preset_candidates: __include: ./../public/preset_candidates/default:/preset_candidates`
-    - `preset_fonts: __include: ./../public/preset_fonts/default:/preset_fonts`
-    - `preset_color_schemes: __include: ./../public/preset_color_schemes/default:/preset_color_schemes`
-    - `preset_keys: __include: ./../public/preset_keys/default:/preset_keys`
+  - 在 `t9/theme.yaml` 开头，你会看到类似这样的写法（注意 `__include` 是**另起一行、缩进**写的，不是和键名同一行）：
+    ```yaml
+    style:
+      __include: ./../public/style/default:/style
+    preset_styles:
+      __include: ./../public/preset_styles/default:/preset_styles
+    preset_candidates:
+      __include: ./../public/preset_candidates/default:/preset_candidates
+    preset_fonts:
+      __include: ./../public/preset_fonts/default:/preset_fonts
+    preset_color_schemes:
+      __include: ./../public/preset_color_schemes/default:/preset_color_schemes
+    preset_keys:
+      __include: ./../public/preset_keys/default:/preset_keys
+    ```
   - 可以简单理解为：
     - `__include: A:/B` 表示「从文件/目录 A 里，把路径 B 对应的那一段配置**拷贝过来用**」。
     - 这样 `t9` 主题就可以直接复用 `public` 里的默认样式、颜色和键盘预设。
 
 - **主题里的 preset_keyboards 如何用到 public？**
-  - 在 `t9/theme.yaml` 里，`preset_keyboards` 下会有这样的配置：
-    - `__include: ./../public/preset_menu/default:/preset_menu/default_menu`
-  - 而 `themes/public/preset_keyboards/default.yaml` 中，则定义了默认的字母键盘布局（QWERTY 行、按键大小、间距等）。
+  - 在 `t9/theme.yaml` 里，`preset_keyboards` 下会以 `__include` 引用 public 的按键行与菜单，例如：
+    - `__include: ./../public/preset_keyboards/t9_keys:/t9_key_1`（引用 T9 按键行）
+    - `__include: ./../public/preset_keyboards/bottom_func_keys:/bottom_number_key`（引用底部功能键）
+    - `__include: ./../public/preset_menu/default:/preset_menu/symbol_menu`（引用符号菜单）
+  - 而 `themes/public/preset_keyboards/` 下的文件（如 `default.yaml`）则定义了默认的字母键盘布局（QWERTY 行、按键大小、间距等）。
   - 多个主题（比如 `t9` 和别的主题）可以共享这一份默认键盘布局，再各自加一点点差异配置。
 
 > 如果你只是想「改一个主题的颜色或布局」，建议：
@@ -197,11 +227,13 @@
 `schemas/` 目录里放的是**输入方案**，比如全拼、双拼、五笔等。我们用一个稍微技术一点、但尽量好懂的方式来解释：
 
 - **子目录 = 一大类方案家族**
-  - 例如：
+  - 当前实际存在的方案家族目录：
     - `bim-pinyin/`：拼音相关的所有方案（全拼、各种双拼、T9 拼音等）。
     - `bim-wubi/`：五笔方案。
+    - `bim-stroke/`：笔画方案。
+    - `bim-cangjie/`：仓颉方案。
     - `zhuyin/`：注音方案。
-    - `wanxiang/` 等：其他方案家族。
+    - `wanxiang/`：万象方案家族。
   - 打开 `bim-pinyin/` 可以看到很多文件：
     - `xxx.schema.yaml`：方案主配置（最关键）。
     - `xxx.custom.yaml`：用户 / 默认的个性化覆盖配置。
@@ -256,7 +288,8 @@
 
 - **结合实际目录来理解**
   - 现在的项目里，`schemas/bim-pinyin/` 已经包含了一整套拼音方案家族：
-    - 比如 `bim_t9.schema.yaml`、`double_pinyin.schema.yaml`、`rime_ice.schema.yaml` 等等。
+    - 比如 `bim_t9.schema.yaml`、`bim_t14.schema.yaml`、`double_pinyin.schema.yaml`、各种双拼变体（`double_pinyin_mspy/_sogou/_flypy/_ziguang` 及其 `_14` / `_18` 版本）、以及 `rime_ice_18.schema.yaml`、`rime_ice_26.schema.yaml` 等等。
+    - 注意：并不存在裸的 `rime_ice.schema.yaml`，实际是带键位后缀的 `rime_ice_18` / `rime_ice_26`；`space.yaml` 默认的 `schema_id: rime_ice_26` 就指向后者。
   - 如果你将来需要导入一套全新的方案，可以大致按这样准备 zip 包：
     - zip 里面有一个目录，比如 `my_schema/`；
     - 这个目录里至少有一个 `my_schema.schema.yaml`；

--- a/fonts/README.md
+++ b/fonts/README.md
@@ -12,13 +12,17 @@
 
 ```text
 /space/fonts/
-  ├── ark-pixel-font/
+  ├── default/                       # 系统默认字体（仅 info.yaml，无字体文件，走系统字体）
+  │   └── info.yaml
+  ├── jf-openhuninn-2.1/             # 仓库当前内置的字体示例
   │   ├── info.yaml
-  │   └── ark-pixel-10px-monospaced-zh_cn.ttf
-  └── your-font/
+  │   └── jf-openhuninn-2.1.ttf
+  └── your-font/                     # 你新增的字体
       ├── info.yaml
       └── your-font.ttf
 ```
+
+> 当前仓库内置两套字体：`default/`（系统字体，无字体文件）与 `jf-openhuninn-2.1/`（justfont 粉圆，`.ttf`）。
 
 ## 2. 快速导入步骤
 
@@ -30,7 +34,7 @@
 
 ## 3. info.yaml 配置模板
 
-可参考 `/space/fonts/ark-pixel-font/info.yaml`。
+可参考 `/space/fonts/jf-openhuninn-2.1/info.yaml`。
 
 ```yaml
 id: your-font-id
@@ -59,7 +63,7 @@ font_dir: fonts/
 
 说明：
 
-- `font`: 默认字体目录名（例如 `ark-pixel-font`）。
+- `font`: 默认字体目录名（例如 `default` 或 `jf-openhuninn-2.1`）。
 - `font_dir`: 字体根目录（通常为 `fonts/`）。
 
 如果不修改，系统会使用当前默认值；你也可以通过应用内“字体”列表动态切换。

--- a/haptics/README.md
+++ b/haptics/README.md
@@ -4,27 +4,35 @@
 
 本文档包含 10 种不同风格的虚拟键盘按键触感方案，每种方案都严格遵循 HarmonyOS 振动开发规范。每种风格包含 4 个触感配置文件，分别对应不同的按键类型。
 
+除这 10 种风格外，仓库还内置 3 个特殊方案：`default`（默认）、`system`（系统，`space.yaml` 默认的 `haptic: system` 即指向它）、`power`（强力，含 `power_one/` 子方案）。它们结构更简（见下）。
+
 ## 目录结构
 
 ```
-keyboard_haptics/
+haptics/
 ├── gentle/          # 轻柔触感
 ├── crisp/           # 清脆触感
 ├── mechanical/      # 机械键盘触感
 ├── typewriter/      # 打字机触感
 ├── modern/          # 现代简约触感
-├── strong/          # 强劲有力触感
+├── strong/          # 强劲有力触感（含 power_one/ 子方案）
 ├── bouncy/          # 弹性触感
 ├── precise/         # 精准触感
 ├── comfortable/     # 舒适触感
-└── gaming/          # 游戏触感
+├── gaming/          # 游戏触感
+├── default/         # 默认方案（仅 default.json）
+├── system/          # 系统方案（仅 info.yaml，使用系统默认振动）
+└── power/           # 强力方案（default.json + power_one/ 子方案）
 ```
 
-每个目录包含 4 个 JSON 文件：
+上面 10 种风格目录各包含 4 个 JSON 文件：
 - `default.json` - 默认按键触感
 - `return.json` - 回车键触感
 - `backspace.json` - 删除键触感
 - `space.json` - 空格键触感
+
+**每个方案目录还包含一个 `info.yaml`**（名片信息：`name`、`description`、`version`、`create_date` 等）。
+`default` / `system` / `power` 三个特殊方案不一定包含全部 4 个 JSON：`system` 只有 `info.yaml`（走系统默认振动），`default` 只有 `default.json`，`power` 含 `default.json` 并在 `power_one/` 下另有一套配置。
 
 ## 方案详细说明
 
@@ -179,7 +187,7 @@ keyboard_haptics/
 import vibrator from '@ohos.vibrator';
 
 // 加载触感文件
-const hapticFile = 'keyboard_haptics/crisp/default.json';
+const hapticFile = 'haptics/crisp/default.json';
 
 // 触发振动
 vibrator.startVibration({
@@ -200,7 +208,10 @@ vibrator.startVibration({
 
 ## 文件清单
 
-共计 **40 个 JSON 文件**，分布在 10 个目录中：
+10 种风格方案共计 **40 个 JSON 文件**（每种 4 个），分布在 10 个目录中。
+此外 `default/`（1 个 JSON）、`power/`（含 `power_one/`，共 2 个 JSON）、`system/`（0 个 JSON）三个特殊方案另算，且每个方案目录都附带一个 `info.yaml`。
+
+10 种风格的 JSON 清单：
 
 ```
 ✅ gentle/default.json

--- a/sounds/README.md
+++ b/sounds/README.md
@@ -1,52 +1,59 @@
 # 键盘音效配置指南
 
 ## 音效文件结构
-键盘音效文件需要按照以下结构放置： 
+
+`sounds/` 下每个子目录是**一套音效主题**，目录名就是 `space.yaml` 里 `sound_effect` 字段引用的名字。
+当前仓库内置 5 套主题：
+
+```text
 space/sounds/
-├── default/ # 默认音效目录
-│ ├── default.wav # 默认按键音效
-│ ├── a.wav # 字母A的音效
-│ ├── b.wav # 字母B的音效
-│ └── ... # 其他按键音效
-└── other_theme/ # 其他音效主题目录
-├── default.wav
-└── ...
+├── default/          # 默认音效（仅 default.wav + 备用 default2.wav）
+│   ├── default.wav
+│   ├── default2.wav
+│   └── info.yaml
+├── default2/         # 另一套默认风格
+│   ├── default.wav
+│   ├── backspace.wav
+│   ├── return.wav
+│   ├── space.wav
+│   └── info.yaml
+├── 叮叮/
+├── 地下工作者/
+└── 木鱼/
+    ├── default.wav
+    ├── backspace.wav
+    ├── return.wav
+    ├── space.wav
+    └── info.yaml
+```
+
+每套主题目录里通常包含：
+
+- 若干 `.wav` 音效文件（见下方命名规则）；
+- 一个 `info.yaml`，描述这套音效的名片信息（`name`、`author`、`version`、`url`、`description` 等）。
 
 ## 音效文件命名规则
 
-1. 所有音效文件必须使用小写字母命名，扩展名为`.wav`
-2. 文件名对应键码的名称，可参考以下对照表:
+1. 所有音效文件使用小写字母命名，扩展名为 `.wav`。
+2. 文件名对应**按键类型**。当前内置主题实际使用的是以下四个：
 
-### 常用按键音效文件名
-- 字母键: `a.wav` 到 `z.wav`
-- 数字键: `0.wav` 到 `9.wav` 
-- 特殊符号:
-  - 空格键: `space.wav`
-  - 回车键: `return.wav`
-  - 退格键: `backspace.wav`
-  - 标点符号: 
-    - 逗号: `comma.wav`
-    - 句号: `period.wav`
-    - 问号: `question.wav`
-    - 感叹号: `exclam.wav`
-    
-### 功能键音效
-- `tab.wav`: Tab键
-- `caps_lock.wav`: 大写锁定键
-- `shift_l.wav`: 左Shift键
-- `shift_r.wav`: 右Shift键
-- `control_l.wav`: 左Ctrl键
-- `control_r.wav`: 右Ctrl键
-- `alt_l.wav`: 左Alt键
-- `alt_r.wav`: 右Alt键
+   - 默认按键：`default.wav`
+   - 空格键：`space.wav`
+   - 回车键：`return.wav`
+   - 退格键：`backspace.wav`
+
+   （`default/` 主题额外提供一个 `default2.wav` 作为备用默认音。）
 
 ## 默认音效
-如果某个按键没有对应的音效文件，系统会播放`default.wav`作为默认音效。建议始终在音效目录中包含`default.wav`文件。
 
-## 音效主题
-1. 在`sounds`目录下创建新的主题文件夹
-2. 将音效文件放入主题文件夹中
-3. 主题文件夹中的音效文件命名规则与默认主题相同
+按键播放时，系统会先查找与该按键类型对应的 `.wav`；如果某个按键没有对应文件，就回退播放 `default.wav`。因此**每套主题都应至少包含 `default.wav`**。
+
+## 新增音效主题
+
+1. 在 `sounds/` 下创建新的主题文件夹（目录名将作为 `sound_effect` 的取值）。
+2. 放入至少 `default.wav`，按需再加 `space.wav` / `return.wav` / `backspace.wav`。
+3. 添加一个 `info.yaml` 描述这套主题。
+4. 在 `space.yaml` 里把 `sound_effect` 改成你的目录名即可启用。
 
 ## 注意事项
 1. 所有音效文件必须是WAV格式

--- a/speeches/README.md
+++ b/speeches/README.md
@@ -22,15 +22,20 @@
 ```text
 resources/space/speeches/
 ├── default/
-│   └── info.yaml
+│   ├── info.yaml        # 界面说明卡片
+│   └── speech.yaml      # provider 与凭据配置
 └── volcengine/
-    └── info.yaml
+    ├── info.yaml
+    └── speech.yaml
 ```
 
 你可以把它理解成：
 
 - 文件夹名 = 这个语音服务的内部名字
-- `info.yaml` = 这个语音服务的说明卡片
+- `info.yaml` = 这个语音服务的**说明卡片**（页面上显示什么、缺 key 时弹什么）
+- `speech.yaml` = 这个语音服务的**接入配置**（用哪个 provider、要哪些密钥）
+
+> 注意：每个语音服务目录下其实有**两个**配置文件。本文大部分篇幅讲 `info.yaml`，`speech.yaml` 的说明见下方「`speech.yaml` 是什么」一节。
 
 程序会读取 `info.yaml`，然后决定：
 
@@ -40,6 +45,39 @@ resources/space/speeches/
 - 缺少 key 时弹窗显示什么按钮
 - “去申请”按钮跳到哪个网址
 - “配置 key”按钮跳到哪个补丁设置页
+
+---
+
+## 一·补、`speech.yaml` 是什么
+
+`info.yaml` 管「页面长什么样」，`speech.yaml` 管「真正用哪个语音引擎、要哪些密钥」。
+
+当前仓库里两个例子：
+
+- `default/speech.yaml`：本地（离线）语音，只有一行
+  ```yaml
+  provider: local
+  ```
+
+- `volcengine/speech.yaml`：火山引擎（豆包）云端语音，需要密钥
+  ```yaml
+  # 语音服务提供商
+  provider: volcengine
+  # 豆包语音应用密钥
+  appKey: ''
+  # 豆包语音访问密钥
+  accessKey: ''
+  # 是否启用自动标点符号（true 自动加标点 / false 不加）
+  enablePunc: true
+  ```
+
+字段说明：
+
+- `provider`：用哪个语音引擎。目前支持 `local`（系统本地识别）与 `volcengine`（火山引擎云端）。
+- `appKey` / `accessKey`：云端 provider 的密钥，留空表示尚未配置（用户需在 App 里通过对应补丁页填写）。
+- `enablePunc`：是否让识别结果自动带标点（仅部分 provider 支持）。
+
+> 一句话：**新增一个云端语音服务时，除了写 `info.yaml`，还要在同目录放一个 `speech.yaml` 指定 `provider` 和密钥字段。**
 
 ---
 


### PR DESCRIPTION
## 概述

逐一对照 `space` 资源仓的磁盘实现，审阅了全部 11 个文档文件，修正了存在「文档漂移」的 5 个 README。其余文档（`plugins/calc`、`tutorials/custom_phrase`、`patches/README`、`patches/patch方法论`、`themes/README`）经核验准确，未改动。

仅文档改动，未触碰任何资源 / 配置文件；所有 Markdown 代码块围栏已校验配对。

## 改了什么

### `README.md`（根，漂移最多）
- **§2 space.yaml 字段**：补齐缺失的 `schema_id`、`font`/`font_dir`、`speech`/`speech_dir`、`haptic`/`haptic_dir`、`global_keyboard_menu`；修正 `theme: t9` → `default`
- **§3 子目录**：补上漏掉的 `fonts/`、`speeches/`、`tutorials/`
- **§6 主题**：`__include` 语法改为真实的「另起一行缩进」多行 YAML；示例 `default_menu` → 实际的 `symbol_menu`
- **§7 方案**：补上 `bim-stroke`、`bim-cangjie` 家族；修正不存在的 `rime_ice.schema.yaml` → 实际的 `rime_ice_18` / `rime_ice_26`
- §8 `use_theme` 映射经核验全部正确，未改

### `fonts/README.md`
- 把不存在的 `ark-pixel-font` 示例换成真实的 `default/` 与 `jf-openhuninn-2.1/`

### `speeches/README.md`
- 补全此前完全未提及的 `speech.yaml`（provider + 密钥配置），新增专门章节并修正目录树

### `sounds/README.md`
- 重写结构 / 命名：实际是 5 套命名主题 + `info.yaml`，实用音效为 `default`/`space`/`return`/`backspace` 四类，而非原文档写的 `a.wav`–`z.wav` 逐键文件

### `haptics/README.md`
- 补上 `default`/`system`/`power` 三个特殊方案与各目录的 `info.yaml`；目录头 `keyboard_haptics/` → `haptics/`；修正集成示例路径

## 审阅说明

各项修正均依据对实际目录内容的核对（space.yaml 字段、themes/ 与 schemas/ 实际结构、各 info.yaml / speech.yaml 真实内容）。`symbols/`、`emoticons/` 本就无 README（仅单一 default 配置，根 README 的子目录一览已覆盖）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)