### PR TITLE
feat(patches): 新增中/英只换键盘与记住英文键盘补丁

### DIFF
--- a/patches/english_keyboard_lock/info.yaml
+++ b/patches/english_keyboard_lock/info.yaml
@@ -1,0 +1,6 @@
+author: "BIM"
+create_time: "2026-08-18"
+name: "记住英文键盘"
+update_time: "2026-08-20"
+url: ""
+version: 1.1.1

--- a/patches/english_keyboard_lock/patch.yaml
+++ b/patches/english_keyboard_lock/patch.yaml
@@ -1,0 +1,36 @@
+# 英文键盘锁定
+# 给各断点 preset_keyboards/english* 的 lock 加开关。
+# lock: true 时，切到英文键盘后会记住该页（切应用后仍停留在英文键盘）。
+
+patch_to: "{$current_theme}"
+patch:
+  - title: "记住英文键盘"
+    key: "english_keyboard_lock_enabled"
+    description: "切到英文键盘后，换成别的应用再回来，是否仍停在英文键盘"
+    patch_to: "{$current_theme}"
+    bind_control: "english_keyboard_lock_enabled"
+    patch:
+      "preset_keyboards/english/lock": "{$english_keyboard_lock}"
+      "preset_keyboards/english_sm_md/lock": "{$english_keyboard_lock}"
+      "preset_keyboards/english_land/lock": "{$english_keyboard_lock}"
+      "preset_keyboards/english_md_sm/lock": "{$english_keyboard_lock}"
+      "preset_keyboards/english_md_lg/lock": "{$english_keyboard_lock}"
+      "preset_keyboards/english_md_md/lock": "{$english_keyboard_lock}"
+      "preset_keyboards/english_lg_sm/lock": "{$english_keyboard_lock}"
+
+controls:
+  stringsTable: "Root"
+  preferences:
+    - type: group
+      title: 英文键盘
+      footer_text: 先打开「启用此设置」。打开「记住英文键盘」时，换到别的应用再回来仍是英文键盘；关掉则会回到中文键盘
+    - type: toggle_switch
+      title: 启用此设置
+      key: english_keyboard_lock_enabled
+      default_value: false
+      toggle_style: switch
+    - type: toggle_switch
+      title: 记住英文键盘
+      key: english_keyboard_lock
+      default_value: true
+      toggle_style: switch

--- a/patches/english_no_schema_switch/info.yaml
+++ b/patches/english_no_schema_switch/info.yaml
@@ -1,0 +1,6 @@
+author: "BIM"
+create_time: "2026-08-18"
+name: "中/英只换键盘"
+update_time: "2026-08-20"
+url: ""
+version: 1.1.1

--- a/patches/english_no_schema_switch/patch.yaml
+++ b/patches/english_no_schema_switch/patch.yaml
@@ -1,0 +1,34 @@
+# 中英键不切方案
+# 去掉各断点 eisu_toggle_ABC_english_*_schema_easy_en 组合里的 {eisu_toggle_schema_en}，
+# 只切对应英文键盘页，不自动切换到 easy_en 方案。
+
+patch_to: "{$current_theme}"
+patch:
+  - title: "中/英只换键盘"
+    key: "english_no_schema_switch"
+    description: "点「中/英」只换成英文键盘，不切换输入方案"
+    patch_to: "{$current_theme}"
+    bind_control: "english_no_schema_switch"
+    patch:
+      # 部分替换 text，保留各主题自定义的 icon / label
+      "preset_keys/eisu_toggle_ABC_english_schema_easy_en/text": "{eisu_toggle_ABC_english}"
+      "preset_keys/eisu_toggle_ABC_english_sm_md_schema_easy_en/text": "{eisu_toggle_ABC_english_sm_md}"
+      "preset_keys/eisu_toggle_ABC_english_land_schema_easy_en/text": "{eisu_toggle_ABC_english_land}"
+      "preset_keys/eisu_toggle_ABC_english_md_sm_schema_easy_en/text": "{eisu_toggle_ABC_english_md_sm}"
+      "preset_keys/eisu_toggle_ABC_english_md_lg_schema_easy_en/text": "{eisu_toggle_ABC_english_md_lg}"
+      "preset_keys/eisu_toggle_ABC_english_md_md_schema_easy_en/text": "{eisu_toggle_ABC_english_md_md}"
+      "preset_keys/eisu_toggle_ABC_english_lg_sm_schema_easy_en/text": "{eisu_toggle_ABC_english_lg_sm}"
+      # t26_pro / custom_t26_pro 菜单里用了这个别名
+      "preset_keys/eisu_toggle_ABC_english_schema_sm_md_easy_en/text": "{eisu_toggle_ABC_english_sm_md}"
+
+controls:
+  stringsTable: "Root"
+  preferences:
+    - type: group
+      title: 中英切换
+      footer_text: 开启后，点「中/英」只换成英文键盘，输入方案保持不变
+    - type: toggle_switch
+      title: 中/英只换键盘
+      key: english_no_schema_switch
+      default_value: false
+      toggle_style: switch


### PR DESCRIPTION
## Summary
- 新增「中/英只换键盘」补丁：点「中/英」只换成英文键盘，不切换输入方案；覆盖默认及多屏布局
- 新增「记住英文键盘」补丁：可选择换到别的应用再回来是否仍停在英文键盘
- 界面文案面向用户，不暴露断点等内部术语

## Test plan
- [ ] 重载 space 后，补丁列表能看到「中/英只换键盘」「记住英文键盘」
- [ ] 开启「中/英只换键盘」后，点「中/英」只换英文键盘，输入方案不变；竖屏/横屏/折叠等布局同样生效
- [ ] 开启「记住英文键盘」并打开「记住」后，切到英文键盘再换应用，回来仍是英文键盘；关掉「记住」后换应用会回到中文键盘
- [ ] 取消激活补丁后，行为恢复为原来的切方案 + 锁定英文键盘


Made with [Cursor](https://cursor.com)