### PR TITLE
feat(themes): 添加空格上屏联想开关

### DIFF
--- a/themes/public/preset_keys/default.yaml
+++ b/themes/public/preset_keys/default.yaml
@@ -210,6 +210,7 @@ preset_keys:
       commonsetting_toggle_show_preedit,
       commonsetting_toggle_text_preview_supported,
       commonsetting_toggle_show_space_schema_name,
+      commonsetting_toggle_space_select_prediction,
       commonsetting_toggle_shift_single_tap_locked,
       commonsetting_toggle_stroke_gesture_filter_enabled,
       commonsetting_toggle_keyboard_handwriting_filter_enabled,
@@ -642,6 +643,7 @@ preset_keys:
   commonsetting_toggle_show_key_upper_label: { type: commonsetting_toggle, icon: "text_and_arrow_up.svg", label: "显示上滑符", send: function, command: commonsetting.toggle, option: [show_key_upper_label] }
   commonsetting_toggle_show_key_upper_label_with_functional: { type: commonsetting_toggle, icon: "chevron_up.svg", label: "功能键显示上滑符", send: function, command: commonsetting.toggle, option: [show_key_upper_label_with_functional] }
   commonsetting_toggle_show_space_schema_name: { type: commonsetting_toggle, icon: "word_book.svg", label: "空格键显示方案名", send: function, command: commonsetting.toggle, option: [show_space_schema_name] }
+  commonsetting_toggle_space_select_prediction: { type: commonsetting_toggle, icon: "space_enlarge.svg", label: "空格上屏联想", send: function, command: commonsetting.toggle, option: [space_select_prediction] }
   commonsetting_toggle_shift_single_tap_locked: { type: commonsetting_toggle, icon: "lock.svg", label: "Shift 单击锁定", send: function, command: commonsetting.toggle, option: [shift_single_tap_locked] }
   commonsetting_toggle_has_moving_preedit: { type: commonsetting_toggle, icon: "text_and_arrow_up_and_down.svg", label: "滑动选择编码", send: function, command: commonsetting.toggle, option: [has_moving_preedit] }
   commonsetting_toggle_swipe_up_enabled: { type: commonsetting_toggle, icon: "swipeup_input.svg", label: "上滑", send: function, command: commonsetting.toggle, option: [swipe_up_enabled] }

--- a/themes/public/preset_menu/default.yaml
+++ b/themes/public/preset_menu/default.yaml
@@ -63,6 +63,7 @@ preset_menu:
      commonsetting_toggle_show_preedit,             # 编码显示
      commonsetting_toggle_text_preview_supported,   # 嵌入编码
      commonsetting_toggle_show_space_schema_name,   # 空格键显示方案名
+     commonsetting_toggle_space_select_prediction, # 空格上屏联想
      commonsetting_toggle_shift_single_tap_locked,  # Shift 单击锁定
      commonsetting_toggle_stroke_gesture_filter_enabled, # 笔画手势筛选
      commonsetting_toggle_keyboard_handwriting_filter_enabled, # 键盘手写


### PR DESCRIPTION
## 变更说明

- 在公共预设键中注册“空格上屏联想”开关
- 将开关加入设置菜单与工具栏自定义候选池
- 复用现有 space_enlarge 图标和 commonsetting.toggle 协议

## 验证

- ./scripts/build_themes.sh：27 个公共主题、3 个方案主题全部编译成功
- ./scripts/install_space.sh：成功
- git diff --check：通过

## 关联 PR

- HarmonyOS 行为与设置接入：https://github.com/jimmy54/hmosbim/pull/265